### PR TITLE
Fix/windows unix cfg guards

### DIFF
--- a/crates/turbomcp-cli/src/transport.rs
+++ b/crates/turbomcp-cli/src/transport.rs
@@ -13,7 +13,7 @@ use turbomcp_transport::child_process::{ChildProcessConfig, ChildProcessTranspor
 #[cfg(feature = "tcp")]
 use turbomcp_transport::tcp::TcpTransportBuilder;
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 use turbomcp_transport::unix::UnixTransportBuilder;
 
 #[cfg(feature = "http")]
@@ -34,7 +34,7 @@ enum ClientInner {
     Stdio(Client<ChildProcessTransport>),
     #[cfg(feature = "tcp")]
     Tcp(Client<turbomcp_transport::tcp::TcpTransport>),
-    #[cfg(feature = "unix")]
+    #[cfg(all(feature = "unix", unix))]
     Unix(Client<turbomcp_transport::unix::UnixTransport>),
     #[cfg(feature = "http")]
     Http(Client<StreamableHttpClientTransport>),
@@ -49,7 +49,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.initialize().await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.initialize().await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.initialize().await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.initialize().await?),
@@ -64,7 +64,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.list_tools().await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.list_tools().await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.list_tools().await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.list_tools().await?),
@@ -83,7 +83,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => client.call_tool(name, arguments, None).await?,
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => client.call_tool(name, arguments, None).await?,
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => client.call_tool(name, arguments, None).await?,
             #[cfg(feature = "http")]
             ClientInner::Http(client) => client.call_tool(name, arguments, None).await?,
@@ -101,7 +101,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.list_resources().await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.list_resources().await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.list_resources().await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.list_resources().await?),
@@ -119,7 +119,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.read_resource(uri).await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.read_resource(uri).await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.read_resource(uri).await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.read_resource(uri).await?),
@@ -136,7 +136,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.list_resource_templates().await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.list_resource_templates().await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.list_resource_templates().await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.list_resource_templates().await?),
@@ -151,7 +151,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.subscribe(uri).await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.subscribe(uri).await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.subscribe(uri).await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.subscribe(uri).await?),
@@ -166,7 +166,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.unsubscribe(uri).await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.unsubscribe(uri).await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.unsubscribe(uri).await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.unsubscribe(uri).await?),
@@ -181,7 +181,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.list_prompts().await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.list_prompts().await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.list_prompts().await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.list_prompts().await?),
@@ -200,7 +200,7 @@ impl UnifiedClient {
             ClientInner::Stdio(client) => Ok(client.get_prompt(name, arguments).await?),
             #[cfg(feature = "tcp")]
             ClientInner::Tcp(client) => Ok(client.get_prompt(name, arguments).await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client.get_prompt(name, arguments).await?),
             #[cfg(feature = "http")]
             ClientInner::Http(client) => Ok(client.get_prompt(name, arguments).await?),
@@ -225,7 +225,7 @@ impl UnifiedClient {
             ClientInner::Tcp(client) => Ok(client
                 .complete_prompt(prompt_name, argument_name, argument_value, context)
                 .await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client
                 .complete_prompt(prompt_name, argument_name, argument_value, context)
                 .await?),
@@ -256,7 +256,7 @@ impl UnifiedClient {
             ClientInner::Tcp(client) => Ok(client
                 .complete_resource(resource_uri, argument_name, argument_value, context)
                 .await?),
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => Ok(client
                 .complete_resource(resource_uri, argument_name, argument_value, context)
                 .await?),
@@ -283,7 +283,7 @@ impl UnifiedClient {
                 client.ping().await?;
                 Ok(())
             }
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => {
                 client.ping().await?;
                 Ok(())
@@ -313,7 +313,7 @@ impl UnifiedClient {
                 client.set_log_level(level).await?;
                 Ok(())
             }
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             ClientInner::Unix(client) => {
                 client.set_log_level(level).await?;
                 Ok(())
@@ -401,14 +401,14 @@ pub async fn create_client(conn: &Connection) -> CliResult<UnifiedClient> {
                 "TCP transport is not enabled (missing 'tcp' feature)".to_string(),
             ))
         }
-        #[cfg(feature = "unix")]
+        #[cfg(all(feature = "unix", unix))]
         TransportKind::Unix => {
             let transport = create_unix_transport(conn).await?;
             Ok(UnifiedClient {
                 inner: ClientInner::Unix(Client::new(transport)),
             })
         }
-        #[cfg(not(feature = "unix"))]
+        #[cfg(not(all(feature = "unix", unix)))]
         TransportKind::Unix => {
             Err(CliError::NotSupported(
                 "Unix socket transport is not enabled (missing 'unix' feature)".to_string(),
@@ -510,7 +510,7 @@ async fn create_tcp_transport(
 }
 
 /// Create Unix socket transport from connection
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 async fn create_unix_transport(
     conn: &Connection,
 ) -> CliResult<turbomcp_transport::unix::UnixTransport> {

--- a/crates/turbomcp-client/src/lib.rs
+++ b/crates/turbomcp-client/src/lib.rs
@@ -249,7 +249,7 @@ pub use turbomcp_transport::streamable_http_client::{
 #[cfg(feature = "tcp")]
 pub use turbomcp_transport::tcp::{TcpTransport, TcpTransportBuilder};
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 pub use turbomcp_transport::unix::{UnixTransport, UnixTransportBuilder};
 
 #[cfg(feature = "websocket")]

--- a/crates/turbomcp-client/src/prelude.rs
+++ b/crates/turbomcp-client/src/prelude.rs
@@ -70,7 +70,7 @@ pub use crate::{RetryPolicy, StreamableHttpClientConfig, StreamableHttpClientTra
 #[cfg(feature = "tcp")]
 pub use crate::{TcpTransport, TcpTransportBuilder};
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 pub use crate::{UnixTransport, UnixTransportBuilder};
 
 #[cfg(feature = "websocket")]

--- a/crates/turbomcp-proxy/Cargo.toml
+++ b/crates/turbomcp-proxy/Cargo.toml
@@ -27,10 +27,6 @@ turbomcp-client = { workspace = true }
 turbomcp-server = { workspace = true, optional = true, features = ["http", "websocket"] }
 turbomcp-auth = { workspace = true, optional = true }
 
-# Unix domain socket transport — only on Unix platforms (macOS, Linux)
-[target.'cfg(unix)'.dependencies]
-turbomcp-transport = { workspace = true, features = ["unix"] }
-
 # Async runtime
 tokio = { workspace = true }
 
@@ -88,6 +84,10 @@ ipnetwork = { version = "0.21", features = ["serde"] }
 # Security
 secrecy = { version = "0.10", features = ["serde"] }
 jsonwebtoken = { workspace = true, optional = true }
+
+# Unix domain socket transport — only on Unix platforms (macOS, Linux)
+[target.'cfg(unix)'.dependencies]
+turbomcp-transport = { workspace = true, features = ["unix"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/turbomcp-proxy/examples/schema_export.rs
+++ b/crates/turbomcp-proxy/examples/schema_export.rs
@@ -103,6 +103,7 @@ fn parse_backend() -> Result<ExampleBackend, Box<dyn Error>> {
             let (host, port) = parse_host_port(&endpoint)?;
             BackendTransport::Tcp { host, port }
         }
+        #[cfg(unix)]
         "unix" => {
             let path = value_after(&args, "--unix")
                 .ok_or_else(|| invalid_input("unix backend requires --unix /path/to/socket"))?;

--- a/crates/turbomcp-proxy/examples/unix_socket_backend.rs
+++ b/crates/turbomcp-proxy/examples/unix_socket_backend.rs
@@ -13,9 +13,17 @@
 //!   cargo run -p turbomcp --example unix_server --features unix
 //!   ```
 
+#[cfg(not(unix))]
+fn main() {
+    eprintln!("This example requires a Unix platform.");
+}
+
+#[cfg(unix)]
 use std::path::PathBuf;
+#[cfg(unix)]
 use turbomcp_proxy::proxy::{BackendConfig, BackendConnector, BackendTransport};
 
+#[cfg(unix)]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize tracing for logging

--- a/crates/turbomcp-server/src/builder.rs
+++ b/crates/turbomcp-server/src/builder.rs
@@ -131,7 +131,7 @@ pub enum Transport {
     },
 
     /// Unix domain socket transport (line-based JSON-RPC).
-    #[cfg(feature = "unix")]
+    #[cfg(all(feature = "unix", unix))]
     Unix {
         /// Socket path (e.g., "/tmp/mcp.sock")
         path: String,
@@ -186,7 +186,7 @@ impl Transport {
     /// # Arguments
     ///
     /// * `path` - Socket path (e.g., "/tmp/mcp.sock")
-    #[cfg(feature = "unix")]
+    #[cfg(all(feature = "unix", unix))]
     #[must_use]
     pub fn unix(path: impl Into<String>) -> Self {
         Self::Unix { path: path.into() }
@@ -457,7 +457,7 @@ impl<H: McpHandler> ServerBuilder<H> {
                 super::transport::tcp::run_with_config(&self.handler, &addr, &config).await
             }
 
-            #[cfg(feature = "unix")]
+            #[cfg(all(feature = "unix", unix))]
             Transport::Unix { path } => {
                 super::transport::unix::run_with_config(&self.handler, &path, &config).await
             }

--- a/crates/turbomcp-server/src/handler.rs
+++ b/crates/turbomcp-server/src/handler.rs
@@ -144,7 +144,7 @@ pub trait McpHandlerExt: McpHandler {
     fn run_tcp(&self, addr: &str) -> impl Future<Output = McpResult<()>> + Send;
 
     /// Run on Unix domain socket transport (line-based JSON-RPC).
-    #[cfg(feature = "unix")]
+    #[cfg(all(feature = "unix", unix))]
     fn run_unix(&self, path: &str) -> impl Future<Output = McpResult<()>> + Send;
 
     /// Handle a single JSON-RPC request (for serverless environments).
@@ -193,7 +193,7 @@ impl<T: McpHandler> McpHandlerExt for T {
         async move { super::transport::tcp::run(&handler, &addr).await }
     }
 
-    #[cfg(feature = "unix")]
+    #[cfg(all(feature = "unix", unix))]
     fn run_unix(&self, path: &str) -> impl Future<Output = McpResult<()>> + Send {
         let path = path.to_string();
         let handler = self.clone();

--- a/crates/turbomcp-server/src/transport/mod.rs
+++ b/crates/turbomcp-server/src/transport/mod.rs
@@ -131,7 +131,7 @@ pub mod stdio;
 #[cfg(feature = "tcp")]
 pub mod tcp;
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 pub mod unix;
 
 #[cfg(feature = "channel")]

--- a/crates/turbomcp-transport/src/config.rs
+++ b/crates/turbomcp-transport/src/config.rs
@@ -271,7 +271,7 @@ impl Configs {
     }
 
     /// Default Unix socket configuration
-    #[cfg(feature = "unix")]
+    #[cfg(all(feature = "unix", unix))]
     pub fn unix(path: impl Into<String>) -> TransportConfig {
         TransportConfigBuilder::new(TransportType::Unix)
             .custom("path", path.into())

--- a/crates/turbomcp-transport/src/lib.rs
+++ b/crates/turbomcp-transport/src/lib.rs
@@ -226,8 +226,8 @@ pub mod tcp {
 ///
 /// v3.0: This module re-exports from the `turbomcp-unix` crate.
 /// The implementation has been extracted for modular builds.
-#[cfg(feature = "unix")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unix")))]
+#[cfg(all(feature = "unix", unix))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "unix", unix))))]
 pub mod unix {
     pub use turbomcp_unix::{UnixConfig, UnixTransport, UnixTransportBuilder};
 }
@@ -291,7 +291,7 @@ pub use websocket_bidirectional::{
 #[cfg(feature = "tcp")]
 pub use tcp::TcpTransport;
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 pub use unix::UnixTransport;
 
 // Re-export child process transport (always available)

--- a/crates/turbomcp-transport/tests/unix_tests.rs
+++ b/crates/turbomcp-transport/tests/unix_tests.rs
@@ -1,6 +1,6 @@
 //! Comprehensive tests for Unix domain socket transport implementation
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 mod unix_tests {
     use std::path::{Path, PathBuf};
     use turbomcp_transport::core::{Transport, TransportState, TransportType};

--- a/crates/turbomcp-unix/src/lib.rs
+++ b/crates/turbomcp-unix/src/lib.rs
@@ -65,6 +65,7 @@
     clippy::all
 )]
 #![deny(unsafe_code)]
+#![cfg(unix)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(
     clippy::module_name_repetitions,


### PR DESCRIPTION
## Fix Windows compilation: Unix cfg guards and proxy Cargo.toml section ordering

`cargo build` and `cargo test` were both broken on Windows. This PR fixes three distinct root causes.

---

### Bug 1 — `turbomcp-unix` compiled on Windows

`turbomcp-unix` had no platform guard, so it was always compiled. On Windows, `tokio::net::UnixListener` and `tokio::net::UnixStream` don't exist (they're `#[cfg(unix)]`-gated in tokio), causing compile errors.

**Fix:** Added `#![cfg(unix)]` to `turbomcp-unix/src/lib.rs`, gating the entire crate. Then propagated `#[cfg(all(feature = "unix", unix))]` (replacing bare `#[cfg(feature = "unix")]`) through every crate that re-exports or references unix transport types:

- `turbomcp-transport/src/lib.rs` + `config.rs` + `tests/unix_tests.rs`
- `turbomcp-server/src/builder.rs`, `handler.rs`, `transport/mod.rs`
- `turbomcp-client/src/lib.rs`, `prelude.rs`
- `turbomcp-cli/src/transport.rs`

`turbomcp/src/lib.rs` was already using the correct `#[cfg(all(unix, feature = "unix"))]` form.

---

### Bug 2 — `turbomcp-proxy` dependencies accidentally unix-only

`turbomcp-proxy/Cargo.toml` had `[target.'cfg(unix)'.dependencies]` placed in the **middle** of `[dependencies]`. In TOML, a section header captures everything below it until the next header, so `tokio`, `serde_json`, `bytes`, `axum`, `tracing`, `uuid`, `dashmap`, `secrecy`, and ~40 other direct dependencies were silently unix-only. On Windows, every import of these crates failed with `unresolved import`.

**Fix:** Moved the `[target.'cfg(unix)'.dependencies]` block to after `[dev-dependencies]`, where it no longer captures unrelated entries.

---

### Bug 3 — proxy examples referenced `BackendTransport::Unix` without a platform guard

Two examples failed to compile on Windows because `BackendTransport::Unix` (correctly gated in bug 1's fix) doesn't exist on non-unix platforms:

- `unix_socket_backend.rs` — entire example is unix-only; added a `#[cfg(not(unix))]` stub `main` and gated the real implementation with `#[cfg(unix)]`
- `schema_export.rs` — added `#[cfg(unix)]` to the `"unix"` match arm; the `other =>` catch-all handles it gracefully on Windows

---

### Result

| Command | Before | After |
|---|---|---|
| `cargo build --workspace` | ❌ | ✅ (requires `protoc` for `turbomcp-grpc`, unchanged) |
| `cargo test --workspace` | ❌ | ✅ (excluding `turbomcp-grpc`) |

Unix socket transport remains fully functional on Linux/macOS — the guards are no-ops on those platforms. Windows developers get access to all other transports (stdio, HTTP, WebSocket, TCP) without any code changes required.
