### PR TITLE
Fix/fix just test for windows

### DIFF
--- a/crates/turbomcp/examples/unix_client.rs
+++ b/crates/turbomcp/examples/unix_client.rs
@@ -12,11 +12,16 @@
 //! cargo run --example unix_client --features "unix full-client"
 //! ```
 
+#[cfg(not(windows))] // Gate all imports to avoid unused clippy warnings on Windows
 use std::collections::HashMap;
+#[cfg(not(windows))]
 use std::path::PathBuf;
+#[cfg(not(windows))]
 use turbomcp_client::{Client, Result};
+#[cfg(not(windows))]
 use turbomcp_transport::unix::UnixTransport;
 
+#[cfg(not(windows))]
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -73,5 +78,11 @@ async fn main() -> Result<()> {
     }
 
     tracing::info!("✅ Demo complete");
+    Ok(())
+}
+
+#[cfg(windows)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    eprintln!("The UnixTransport client example is not supported on Windows.");
     Ok(())
 }

--- a/justfile
+++ b/justfile
@@ -18,6 +18,10 @@ crates_dir := "crates"
 target_dir := "target"
 coverage_dir := "coverage"
 
+# Set shell for both unix and Windows environments
+set shell := ["sh", "-euc"]
+set windows-shell := ["sh", "-euc", "--"] # Requires Git to be installed with `sh` in PATH if on Windows
+
 # Version info (computed)
 version := `grep '^version' crates/turbomcp/Cargo.toml | head -1 | cut -d '"' -f 2`
 git_hash := `git rev-parse --short HEAD 2>/dev/null || echo "unknown"`
@@ -127,8 +131,6 @@ build-all-features:
 # Run comprehensive test suite (tests + clippy + fmt)
 [group: 'test']
 test:
-  #!/usr/bin/env bash
-  set -euo pipefail
   echo "Running comprehensive test suite..."
   echo "Step 1/5: Running unit and integration tests..."
   cargo test --workspace --lib --exclude turbomcp-transport


### PR DESCRIPTION
# Issue

Running `just test` on Windows did not work because the justfile relied on a unix shell for the test commands. Explicitly setting the shells and removing the shebang and pipe fail fixes the issue.

Also, running `cargo test` and `cargo test --all` previously worked (still does), but running `just test` ran the unix client test, so I added explicit compiler flag gating. Also added to all of the dependencies to prevent clippy from considering it dead code on Windows. 

Overall improves portability substantially.

## Known Gap

Technically if the grep fails on this line of the justfile:

```
version := `grep '^version' crates/turbomcp/Cargo.toml | head -1 | cut -d '"' -f 2`
```

then it would incorrectly continue due to no pipefail. But that grep should never fail since the Cargo.toml will always have a version defined. Also technically that gap was pre-existing.

---

Tested everything on Windows and Linux machines and we're all green. Not tested on MacOS because I don't have a Macbook. Please test everything on your Macbook before merging. Thanks!