### PR TITLE
fix: re-export types required by McpHandler public methods

### DIFF
--- a/crates/turbomcp-server/src/lib.rs
+++ b/crates/turbomcp-server/src/lib.rs
@@ -132,6 +132,7 @@ pub use router::{
 
 // Re-export McpHandler from core for unified architecture
 pub use turbomcp_core::handler::McpHandler;
+pub use turbomcp_core::marker::MaybeSend;
 
 /// Internal module for macro-generated code.
 #[doc(hidden)]
@@ -201,6 +202,7 @@ pub mod prelude {
         IntoResourceResult,
         IntoToolResult,
         // Core types
+        ListTasksResult,
         Message,
         Prompt,
         PromptArgument,
@@ -208,7 +210,9 @@ pub mod prelude {
         Resource,
         ResourceContents,
         ResourceResult,
+        ResourceTemplate,
         ServerInfo,
+        Task,
         Tool,
         ToolInputSchema,
         ToolResult,


### PR DESCRIPTION
## Issue

Missing public exports in turbomcp-server facade:

`turbomcp-server/src/lib.rs` is missing re-exports for four types that are part of the required public contract for downstream crates implementing the McpHandler struct manually:

- MaybeSend (turbomcp_core::marker::MaybeSend) is required as a bound on every RPIT async method in a manual McpHandler impl (e.g. -> impl Future<Output = ...> + MaybeSend + 'a). Any crate writing a wrapper layer like AliasLayer or VisibilityLayer must name this type. MaybeSent is currently only reachable with turbomcp_server::__macro_support::turbomcp_core::marker::MaybeSend. Uses a double underscore "private" convention path.
- ResourceTemplate (turbomcp_types::ResourceTemplate) is returned by McpHandler::list_resource_templates(), so any implementor that handles resource templates must name it.
- ListTasksResult (turbomcp_types::ListTasksResult) and Task (turbomcp_types::Task): these are return types of McpHandler::list_tasks(), get_task(), and cancel_task(). 

## Fix

Re-exported the types to facilitate clear access.