### PR TITLE
chore: nitpick- aligned documentation ASCII boxes

### DIFF
--- a/docs/V3_ARCHITECTURE.md
+++ b/docs/V3_ARCHITECTURE.md
@@ -15,68 +15,68 @@ TurboMCP v3 is a major architectural redesign focused on:
 ## Architecture Overview
 
 ```
-┌──────────────────────────────────────────────────────────────────────┐
-│                        Application Layer                              │
-│   ┌──────────────┐  ┌──────────────┐  ┌──────────────┐               │
-│   │   Your MCP   │  │    Demo     │  │   Examples   │               │
-│   │   Server     │  │   Server    │  │              │               │
-│   └──────────────┘  └──────────────┘  └──────────────┘               │
-└──────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│                     Application Layer                             │
+│   ┌──────────────┐  ┌──────────────┐  ┌──────────────┐            │
+│   │   Your MCP   │  │     Demo     │  │   Examples   │            │
+│   │   Server     │  │    Server    │  │              │            │
+│   └──────────────┘  └──────────────┘  └──────────────┘            │
+└───────────────────────────────────────────────────────────────────┘
                               │
                               ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│                        SDK Layer (turbomcp)                           │
-│   • High-level API                                                    │
-│   • Re-exports everything users need                                  │
-│   • Transport runners (run_stdio, run_http)                          │
-└──────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│                        SDK Layer (turbomcp)                       │
+│   • High-level API                                                │
+│   • Re-exports everything users need                              │
+│   • Transport runners (run_stdio, run_http)                       │
+└───────────────────────────────────────────────────────────────────┘
                               │
                               ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│                        Macro Layer (turbomcp-macros)                  │
-│   • #[server] - generates McpHandler implementation                  │
-│   • #[tool] - marks tool handlers, generates JSON schema              │
-│   • #[resource] - marks resource handlers                            │
-│   • #[prompt] - marks prompt handlers                                │
-└──────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│                        Macro Layer (turbomcp-macros)              │
+│   • #[server] - generates McpHandler implementation               │
+│   • #[tool] - marks tool handlers, generates JSON schema          │
+│   • #[resource] - marks resource handlers                         │
+│   • #[prompt] - marks prompt handlers                             │
+└───────────────────────────────────────────────────────────────────┘
                               │
                               ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│                     Runtime Layer (turbomcp-server)                   │
-│   • JSON-RPC routing                                                 │
-│   • Transport implementations (STDIO, HTTP, WebSocket)               │
-│   • Server configuration                                             │
-│   • Connection management                                            │
-└──────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│                     Runtime Layer (turbomcp-server)               │
+│   • JSON-RPC routing                                              │
+│   • Transport implementations (STDIO, HTTP, WebSocket)            │
+│   • Server configuration                                          │
+│   • Connection management                                         │
+└───────────────────────────────────────────────────────────────────┘
                               │
                               ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│                     Protocol Layer (turbomcp-protocol)                │
-│   • Advanced protocol features                                       │
-│   • Session management                                               │
-│   • Capability negotiation                                           │
-│   • Validation                                                       │
-└──────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│                     Protocol Layer (turbomcp-protocol)            │
+│   • Advanced protocol features                                    │
+│   • Session management                                            │
+│   • Capability negotiation                                        │
+│   • Validation                                                    │
+└───────────────────────────────────────────────────────────────────┘
                               │
                               ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│                     Core Layer (turbomcp-core)                        │
-│   • McpHandler trait definition                                      │
-│   • RequestContext (transport-agnostic)                              │
-│   • IntoToolResult, IntoResourceResult traits                        │
-│   • no_std compatible                                                │
-└──────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│                     Core Layer (turbomcp-core)                    │
+│   • McpHandler trait definition                                   │
+│   • RequestContext (transport-agnostic)                           │
+│   • IntoToolResult, IntoResourceResult traits                     │
+│   • no_std compatible                                             │
+└───────────────────────────────────────────────────────────────────┘
                               │
                               ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│                     Types Layer (turbomcp-types)                      │
-│   • ALL MCP type definitions                                         │
-│   • Content types (TextContent, ImageContent, etc.)                  │
-│   • Definition types (Tool, Resource, Prompt, ServerInfo)            │
-│   • Result types (ToolResult, ResourceResult, PromptResult)          │
-│   • Error types (McpError)                                           │
-│   • Single source of truth                                           │
-└──────────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│                     Types Layer (turbomcp-types)                  │
+│   • ALL MCP type definitions                                      │
+│   • Content types (TextContent, ImageContent, etc.)               │
+│   • Definition types (Tool, Resource, Prompt, ServerInfo)         │
+│   • Result types (ToolResult, ResourceResult, PromptResult)       │
+│   • Error types (McpError)                                        │
+│   • Single source of truth                                        │
+└───────────────────────────────────────────────────────────────────┘
 ```
 
 ## Core Design Principles

--- a/docs/V3_UNIFIED_ARCHITECTURE.md
+++ b/docs/V3_UNIFIED_ARCHITECTURE.md
@@ -28,7 +28,7 @@ The original design proposed a single `#[server]` macro that would work for both
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                        Application Layer                                  │
+│                        Application Layer                                 │
 │   ┌──────────────┐  ┌──────────────┐  ┌──────────────┐                   │
 │   │  Native MCP  │  │  Cloudflare  │  │   Browser    │                   │
 │   │   Server     │  │   Worker     │  │   Client     │                   │
@@ -36,34 +36,34 @@ The original design proposed a single `#[server]` macro that would work for both
 └──────────────────────────────────────────────────────────────────────────┘
          │                    │                    │
          ▼                    ▼                    ▼
-┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
-│    turbomcp     │  │  turbomcp-wasm  │  │ turbomcp-wasm   │
-│   (std, tokio)  │  │   (server)      │  │   (browser)     │
-│                 │  │                 │  │                 │
-│ • #[server]     │  │ • McpServer     │  │ • BrowserClient │
-│ • run_stdio()   │  │ • WithAuth      │  │ • FetchTransport│
-│ • run_http()    │  │ • Worker integ  │  │                 │
-│ • run_tcp()     │  │                 │  │                 │
-└─────────────────┘  └─────────────────┘  └─────────────────┘
+┌─────────────────┐  ┌─────────────────┐  ┌──────────────────┐
+│    turbomcp     │  │  turbomcp-wasm  │  │ turbomcp-wasm    │
+│   (std, tokio)  │  │   (server)      │  │   (browser)      │
+│                 │  │                 │  │                  │
+│ • #[server]     │  │ • McpServer     │  │ • BrowserClient  │
+│ • run_stdio()   │  │ • WithAuth      │  │ • FetchTransport │
+│ • run_http()    │  │ • Worker integ  │  │                  │
+│ • run_tcp()     │  │                 │  │                  │
+└─────────────────┘  └─────────────────┘  └──────────────────┘
          │                    │                    │
          └────────────────────┼────────────────────┘
                               ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                     Core Layer (turbomcp-core)                            │
-│   • McpHandler trait (unified, platform-adaptive Send bounds)             │
-│   • RequestContext (minimal, no_std compatible)                           │
-│   • MaybeSend/MaybeSync marker traits                                     │
-│   • Authentication traits (Authenticator, CredentialExtractor)            │
-│   no_std compatible with alloc                                            │
+│                     Core Layer (turbomcp-core)                           │
+│   • McpHandler trait (unified, platform-adaptive Send bounds)            │
+│   • RequestContext (minimal, no_std compatible)                          │
+│   • MaybeSend/MaybeSync marker traits                                    │
+│   • Authentication traits (Authenticator, CredentialExtractor)           │
+│   no_std compatible with alloc                                           │
 └──────────────────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                     Types Layer (turbomcp-types)                          │
-│   • ALL MCP type definitions (Tool, Resource, Prompt, ServerInfo)         │
-│   • Result types (ToolResult, ResourceResult, PromptResult)               │
-│   • Error types (McpError with JSON-RPC codes)                            │
-│   Single source of truth - no_std compatible                              │
+│                     Types Layer (turbomcp-types)                         │
+│   • ALL MCP type definitions (Tool, Resource, Prompt, ServerInfo)        │
+│   • Result types (ToolResult, ResourceResult, PromptResult)              │
+│   • Error types (McpError with JSON-RPC codes)                           │
+│   Single source of truth - no_std compatible                             │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ TurboMCP enables you to build MCP servers with:
   System design, context lifecycle, and design decisions
 
 - **[Deployment](deployment/docker.md)**
-  Deploy to production with Docker, Kubernetes, edge, and observability
+  Deploy to production with Docker, Kubernetes, edge platforms, and observability
 
 </div>
 


### PR DESCRIPTION
Just aligning the ASCII boxes. Pretty sure this won't regress anything; it's all monospace, so it should render the same everywhere alignment wise.