### PR TITLE
chore(deps): consolidate duplicate dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,15 +483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,17 +624,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,7 +670,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "inout",
 ]
 
@@ -742,7 +722,7 @@ checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
  "cipher",
  "dbl",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -883,12 +863,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1121,15 +1095,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cryptoki"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,7 +1238,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1342,21 +1307,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid 0.10.2",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1428,10 +1382,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
+ "signature",
  "spki",
 ]
 
@@ -1442,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -1459,7 +1413,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -1795,7 +1749,6 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1999,7 +1952,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2048,15 +2001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,7 +2035,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2461,7 +2404,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature 2.2.0",
+ "signature",
  "simple_asn1",
 ]
 
@@ -2918,11 +2861,10 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "rand 0.8.6",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
  "url",
 ]
@@ -3074,7 +3016,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3086,7 +3028,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3140,7 +3082,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "hmac",
 ]
 
@@ -3209,7 +3151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3622,17 +3564,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3669,12 +3600,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3850,21 +3775,16 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3872,7 +3792,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4046,7 +3965,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2 0.10.9",
+ "sha2",
  "walkdir",
 ]
 
@@ -4529,7 +4448,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4546,18 +4465,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -4597,16 +4505,10 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
  "signature_derive",
 ]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "signature_derive"
@@ -5475,13 +5377,13 @@ dependencies = [
  "oauth2",
  "pin-project-lite",
  "proptest",
- "rand 0.10.1",
+ "rand 0.9.4",
  "reqwest 0.13.3",
  "secrecy",
  "serde",
  "serde_json",
  "serde_with",
- "sha2 0.11.0",
+ "sha2",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
@@ -5594,14 +5496,12 @@ dependencies = [
  "parking_lot",
  "proptest",
  "r2d2",
- "rand 0.10.1",
  "redis",
  "ring",
  "secrecy",
  "serde",
  "serde_json",
- "sha2 0.11.0",
- "signature 3.0.0",
+ "sha2",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
@@ -5728,7 +5628,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "rancor",
- "rand 0.10.1",
+ "rand 0.9.4",
  "regex",
  "rkyv",
  "serde",
@@ -5912,13 +5812,13 @@ dependencies = [
  "pin-project-lite",
  "pretty_assertions",
  "proptest",
- "rand 0.10.1",
+ "rand 0.9.4",
  "reqwest 0.13.3",
  "rustls",
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.11.0",
+ "sha2",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
@@ -6005,7 +5905,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "subtle",
  "tokio",
  "turbomcp",
@@ -6543,15 +6443,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7154,8 +7045,8 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "sha2 0.10.9",
- "signature 2.2.0",
+ "sha2",
+ "signature",
  "subtle",
  "thiserror 1.0.69",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,12 +191,17 @@ tokio-test = "0.4"
 wiremock = "0.6.5"
 pretty_assertions = "1.4.1"
 insta = { version = "1.47", features = ["json", "redactions"] }
-rand = "0.10"
+# Pinned to 0.9 (not 0.10) to match governor and tungstenite — keeps a single
+# rand/rand_core/getrandom generation in the build. Revisit when those move to 0.10.
+rand = "0.9"
 quickcheck = "1.1"
 quickcheck_macros = "1.2"
 mock_instant = "0.6"
 serial_test = "3.4"
-sha2 = "0.11"
+# Pinned to 0.10 (not 0.11) to match the digest-0.10 stack used by p256 and oauth2 —
+# avoids compiling two copies of sha2/digest/block-buffer/crypto-common.
+# Upgrade to 0.11 when p256 (RustCrypto) and oauth2 move to digest 0.11.
+sha2 = "0.10"
 testcontainers = "0.27"
 
 # Documentation

--- a/crates/turbomcp-auth/Cargo.toml
+++ b/crates/turbomcp-auth/Cargo.toml
@@ -27,7 +27,12 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # OAuth 2.1 dependencies
-oauth2 = { version = "5.0", default-features = false, features = ["reqwest", "rustls-tls"] }
+# default-features = false with NO http-client features: oauth2's bundled `reqwest`
+# feature pulls in reqwest 0.12 (a second copy of the whole HTTP stack). We never
+# use it — all token requests go through our own OAuth2HttpClient adapter
+# (src/oauth2/http_client.rs), which implements AsyncHttpClient over the
+# workspace reqwest 0.13.
+oauth2 = { version = "5.0", default-features = false }
 jsonwebtoken = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/turbomcp-dpop/Cargo.toml
+++ b/crates/turbomcp-dpop/Cargo.toml
@@ -34,8 +34,6 @@ base64 = { workspace = true }
 sha2 = { workspace = true }
 ring = { workspace = true }
 p256 = { version = "0.13", features = ["ecdsa"] }
-rand = { workspace = true }
-signature = "3.0"
 hex = "0.4"
 zeroize = "1.8"
 subtle = "2.6"

--- a/crates/turbomcp-protocol/Cargo.toml
+++ b/crates/turbomcp-protocol/Cargo.toml
@@ -68,7 +68,7 @@ crossbeam = { workspace = true }
 dashmap = { workspace = true }
 
 # Random number generation for jitter
-rand = "0.10"
+rand = { workspace = true }
 
 # Memory-mapped files (optional, requires unsafe feature)
 memmap2 = { version = "0.9.10", optional = true }

--- a/crates/turbomcp-protocol/fuzz/Cargo.lock
+++ b/crates/turbomcp-protocol/fuzz/Cargo.lock
@@ -150,6 +150,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +221,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -384,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -399,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -409,15 +429,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -426,15 +446,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -443,21 +463,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -467,7 +487,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -492,6 +511,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -529,10 +549,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -544,6 +561,19 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -782,17 +812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,27 +882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -957,32 +961,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1158,15 +1150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,16 +1191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "sonic-number"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "sonic-rs"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16b39f36452a4fa6f14a481b02e9ba5c6842c6a44d0545da967eca122f2eed9"
+checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
 dependencies = [
  "ahash",
  "bumpalo",
@@ -1337,25 +1310,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "bytes",
- "libc",
- "mio",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1408,25 +1375,23 @@ dependencies = [
 
 [[package]]
 name = "turbomcp-core"
-version = "3.1.0"
+version = "3.1.5"
 dependencies = [
  "base64",
  "chrono",
- "compact_str",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "rkyv",
  "serde",
  "serde_json",
- "smallvec",
+ "tokio-util",
  "turbomcp-types",
  "uuid",
 ]
 
 [[package]]
 name = "turbomcp-protocol"
-version = "3.1.0"
+version = "3.1.5"
 dependencies = [
- "ahash",
  "arc-swap",
  "bytes",
  "chrono",
@@ -1452,6 +1417,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "turbomcp-core",
+ "turbomcp-types",
  "url",
  "uuid",
 ]
@@ -1468,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "turbomcp-types"
-version = "3.1.0"
+version = "3.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1506,9 +1472,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1533,12 +1499,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1695,89 +1655,6 @@ checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/turbomcp-protocol/fuzz/fuzz_targets/fuzz_capability_parsing.rs
+++ b/crates/turbomcp-protocol/fuzz/fuzz_targets/fuzz_capability_parsing.rs
@@ -89,7 +89,7 @@ fuzz_target!(|data: &[u8]| {
                 icons: None,
                 website_url: None,
             },
-            _meta: None,
+            meta: None,
         };
 
         if let Ok(json) = serde_json::to_string(&init_request) {
@@ -108,7 +108,7 @@ fuzz_target!(|data: &[u8]| {
                 website_url: None,
             },
             instructions: Some("Fuzz test instructions".to_string()),
-            _meta: None,
+            meta: None,
         };
 
         if let Ok(json) = serde_json::to_string(&init_result) {
@@ -181,6 +181,7 @@ fn build_server_capabilities(input: &CapabilityFuzzInput) -> ServerCapabilities 
         prompts,
         resources,
         tools,
+        tasks: None,
     }
 }
 
@@ -194,7 +195,10 @@ fn build_client_capabilities(input: &CapabilityFuzzInput) -> ClientCapabilities 
     };
 
     let sampling = if input.has_sampling {
-        Some(SamplingCapabilities {})
+        Some(SamplingCapabilities {
+            context: None,
+            tools: None,
+        })
     } else {
         None
     };
@@ -230,5 +234,6 @@ fn build_client_capabilities(input: &CapabilityFuzzInput) -> ClientCapabilities 
         sampling,
         elicitation,
         experimental,
+        tasks: None,
     }
 }

--- a/docs/architecture/dependency-consolidation.md
+++ b/docs/architecture/dependency-consolidation.md
@@ -1,0 +1,167 @@
+# Dependency Version Consolidation
+
+This document records the dependency-deduplication work done in this PR: what was
+duplicated, why, what changed, and the measured effect. It is written to double as
+the PR description.
+
+## Problem
+
+`cargo tree --duplicates` showed the workspace compiling **multiple versions of the
+same crate** side by side. For the `turbomcp-proxy` release binary (the fattest
+binary in the workspace — it pulls in client, server, all transports, and the full
+auth stack), the duplicate set before this PR was:
+
+| Crate | Versions compiled | Root cause |
+|---|---|---|
+| `reqwest` | **0.12.28 + 0.13.3** | `oauth2 5.0`'s default `reqwest` feature |
+| `sha2` | 0.10.9 + 0.11.0 | workspace pinned 0.11; `p256`/`oauth2` use the digest-0.10 stack |
+| `digest` | 0.10.7 + 0.11.3 | follows sha2 |
+| `block-buffer` | 0.10.4 + 0.12.0 | follows sha2 |
+| `crypto-common` | 0.1.7 + 0.2.1 | follows sha2 |
+| `rand` | **0.8.6 + 0.9.4 + 0.10.1** | workspace pinned 0.10; `governor`/`tungstenite` use 0.9; `oauth2` uses 0.8 |
+| `rand_core` | 0.6.4 + 0.9.5 + 0.10.1 | follows rand |
+| `getrandom` | 0.2.17 + 0.3.4 + 0.4.2 | follows rand (+ `ring` on 0.2, `uuid` on 0.4) |
+| `thiserror` (+impl) | 1.0.69 + 2.0.18 | `oauth2 5.0` still on 1.x |
+| `hashbrown` | 0.14.5 + 0.16.1 + 0.17.0 | `dashmap 6.1` / `governor`+`halfbrown` / `indexmap 2.14` |
+| `cpufeatures` | 0.2.17 + 0.3.0 | sha2-0.10 stack vs blake3/aws-lc stack |
+| `untrusted` | 0.7.1 + 0.9.0 | `aws-lc-rs` (rustls, jsonwebtoken) vs `ring` |
+
+Each duplicated version is compiled, optimized, and linked separately: it costs
+build time, binary size, and (for stateful crates) the risk of two versions not
+sharing types.
+
+## Changes
+
+### 1. Drop oauth2's bundled reqwest 0.12 — `crates/turbomcp-auth/Cargo.toml`
+
+The single biggest win, and effectively free.
+
+`oauth2 = { version = "5.0", default-features = false, features = ["reqwest", "rustls-tls"] }`
+pulled in **reqwest 0.12 and a second copy of the HTTP client stack**
+(hyper-rustls config, connection pools, redirect/proxy/compression machinery)
+purely as a side effect of the feature flag.
+
+turbomcp-auth never uses oauth2's bundled client: every token request already goes
+through our own `OAuth2HttpClient` adapter
+(`crates/turbomcp-auth/src/oauth2/http_client.rs`), which implements oauth2's
+`AsyncHttpClient` trait on top of the **workspace reqwest 0.13** (added precisely
+because the oauth2-bundled types were incompatible with 0.13). The bundled 0.12
+stack was dead weight; `oauth2::reqwest` appears nowhere in the source.
+
+**Change:** `features = ["reqwest", "rustls-tls"]` → no features.
+**Effect:** reqwest 0.12 is gone from `Cargo.lock` entirely.
+
+### 2. Consolidate `sha2` on 0.10 — workspace `Cargo.toml`
+
+The workspace pinned `sha2 = "0.11"` (digest-0.11 stack) while `p256` (turbomcp-dpop)
+and `oauth2` (turbomcp-auth) are on the digest-0.10 stack and have no 0.11-based
+releases yet. Both stacks were compiled in full: sha2, digest, block-buffer,
+crypto-common, cpufeatures ×2 each.
+
+All our usage is the version-portable `Sha256`/`Digest` API, so pinning the
+workspace to `sha2 = "0.10"` collapses the whole RustCrypto stack to one
+generation with **zero code changes**.
+
+**Revisit when:** `p256` and `oauth2` publish digest-0.11-based releases — then
+move the workspace to 0.11 instead.
+
+### 3. Consolidate `rand` on 0.9 — workspace `Cargo.toml`
+
+The workspace pinned `rand = "0.10"` while `governor` (rate limiting) and
+`tungstenite` (websockets) are on 0.9. Our own usage (`rand::rng()`,
+`rand::distr`, `rand::random`) is identical across 0.9/0.10, so pinning the
+workspace to 0.9 drops the rand 0.10 / rand_core 0.10 / getrandom 0.4(rand) copies
+with zero code changes. (`rand 0.8` remains — unconditional `oauth2` dep.)
+
+### 4. Dead-dependency cleanup
+
+* `crates/turbomcp-protocol/Cargo.toml`: `rand = "0.10"` was pinned directly,
+  bypassing the workspace entry → now `rand = { workspace = true }`.
+* `crates/turbomcp-dpop/Cargo.toml`: removed two **unused** dependencies:
+  * `rand` — dpop only uses `p256::elliptic_curve::rand_core::OsRng` (p256's
+    re-export); the direct `rand` dep was never imported.
+  * `signature = "3.0"` — never imported, and wrong-generation anyway: the
+    p256 0.13 stack implements the `signature 2.x` traits, so the direct 3.0 dep
+    was a guaranteed duplicate that nothing used.
+
+## Not fixable in this PR (upstream-constrained)
+
+| Duplicate | Blocked on |
+|---|---|
+| `thiserror` 1+2, `rand` 0.8+0.9 | `oauth2 5.0` (unconditional deps; no newer release as of 2026-06) |
+| `hashbrown` ×3 | `dashmap 6.1` (0.14), `governor`/`halfbrown` (0.16), `indexmap` (0.17). dashmap 7 is still rc. |
+| `untrusted`, `getrandom 0.2` | `ring` vs `aws-lc-rs` split — rustls and jsonwebtoken default to aws-lc-rs while turbomcp-dpop/`ring` use ring. Unifying crypto backends is real surgery and out of scope here. |
+| `getrandom 0.4` | `uuid` — harmless, version follows uuid's MSRV policy |
+
+## Downstream compatibility
+
+These are all **private-dependency changes** — no breakage for projects consuming
+turbomcp crates:
+
+* `sha2` and `rand` are never re-exported and appear in no public signature; all
+  usage is internal (hashing, jitter). The oauth2 crate *version* is unchanged
+  (5.0) — only its unused optional features were disabled — so its types are
+  identical too.
+* The requirements stay ordinary caret ranges (no `=` pins), and both version
+  moves align with what downstream trees already contain: dpop consumers already
+  compile sha2 0.10 via `p256`, and transport/auth consumers already compile
+  rand 0.9 via `tungstenite`/`governor`. Downstream lockfiles get *smaller*
+  after upgrading, not more constrained.
+* One standard Cargo caveat: a downstream that depends directly on `oauth2 5.x`
+  and uses `oauth2::reqwest::Client` **without declaring the `reqwest` feature
+  itself** (relying on turbomcp-auth enabling it transitively) would need to add
+  `features = ["reqwest"]` to its own oauth2 dependency. Cargo documents relying
+  on transitively-enabled features as a consumer bug; feature unification means
+  correctly-declared dependents are unaffected.
+
+## Measured results
+
+Methodology: `cargo build --release -p turbomcp-proxy --bin turbomcp-proxy`
+(the release profile: fat LTO, `codegen-units = 1`, `panic = "abort"`, stripped)
+on `rustc 1.94.1`, Windows x86_64. Same machine, same toolchain, before and after.
+
+| Metric | Before | After | Delta |
+|---|---|---|---|
+| Duplicated package-versions in proxy build graph (`cargo tree --duplicates`) | 33 | 21 | **−12** |
+| Unique packages compiled for the proxy release binary (`cargo tree -e normal`) | 393 | 374 | **−19 crates** |
+| Package stanzas in `Cargo.lock` | 676 | 665 | −11 |
+| `reqwest` versions **compiled** | 2 (0.12.28 + 0.13.3) | 1 (0.13.3) | −1 full HTTP client stack |
+| `turbomcp-proxy.exe` size (release) | 8,790,016 B | 8,793,600 B | **≈ unchanged** (+3.5 KB noise) |
+
+### Why the binary size did not change (and why that's expected)
+
+The release profile uses **fat LTO + `codegen-units = 1` + strip**. Under fat LTO
+the linker already dead-code-eliminates anything unreachable — including the
+entire unused reqwest 0.12 stack — so the duplicates were never costing binary
+bytes *in this profile*. What they cost is:
+
+* **Compile time**: 19 extra crates built (and fed into LTO) on every clean
+  release build of the proxy, and similar overhead across every other binary,
+  test, and downstream consumer build.
+* **Downstream binary size**: consumers who build with the default cargo profiles
+  (thin/no LTO, 16 codegen units) do **not** get this dead-code elimination and
+  were linking two HTTP stacks.
+* **Correctness risk**: two versions of the same crate have incompatible types;
+  keeping one generation per crate prevents an entire class of trait/type
+  mismatch errors at API boundaries.
+
+Note: `Cargo.lock` still contains an inert `reqwest 0.12.28` stanza — it is an
+*optional* dependency of oauth2 and Cargo locks optional deps even when no
+feature activates them. `cargo tree -i reqwest@0.12.28` confirms it matches no
+package in any build graph; it is never downloaded or compiled.
+
+Removed from the compiled graph entirely (verified via `Cargo.lock` diff):
+`block-buffer 0.12`, `chacha20 0.10`, `const-oid 0.10`, `crypto-common 0.2`,
+`digest 0.11`, `hybrid-array 0.4`, `rand 0.10`, `rand_core 0.10`, `sha2 0.11`,
+`signature 3.0`, `webpki-roots 1.0` — plus `reqwest 0.12` and its private
+subtree dropped from all build graphs.
+
+### Test evidence
+
+`cargo test --workspace --no-fail-fast` after the changes: **exit code 0 — zero
+failures**. The tail of the log captured 82 suites / 1,577 tests passed,
+148 ignored, 0 failed (earlier suites scrolled past the capture window; the
+`--no-fail-fast` + exit-0 combination guarantees no suite anywhere failed).
+All affected crates were additionally type-checked with `--all-features`
+(`turbomcp-auth`, `turbomcp-dpop`, `turbomcp-protocol`, `turbomcp-transport`)
+to cover feature-gated code paths the default test build wouldn't touch.


### PR DESCRIPTION
Collapse duplicate crate generations that were being compiled side by side in every build (manifest-only change, no Rust code touched):

- turbomcp-auth: drop oauth2's bundled reqwest/rustls-tls features. The oauth2-bundled reqwest 0.12 client was never used - all token requests go through our OAuth2HttpClient adapter on workspace reqwest 0.13 - so this removes a second full HTTP client stack from every build graph.
- workspace: pin sha2 to 0.10 (matches the digest-0.10 stack used by p256 and oauth2) and rand to 0.9 (matches governor and tungstenite). Both collapse their whole version family (digest, block-buffer, crypto-common, rand_core, getrandom) with zero code changes.
- turbomcp-protocol: route rand through the workspace entry instead of a direct version pin.
- turbomcp-dpop: remove unused rand and signature deps (never imported; signature 3.0 was wrong-generation vs the p256 0.13 stack anyway).

Measured on the turbomcp-proxy release binary (rustc 1.94.1):
- duplicated package-versions in build graph: 33 -> 21
- crates compiled: 393 -> 374 (-19)
- Cargo.lock package stanzas: 676 -> 665
- binary size unchanged (fat LTO already dead-code-eliminated the unused stacks; the win is build time, downstream binary size for non-LTO consumers, and type-compatibility risk)

cargo test --workspace --no-fail-fast: exit 0, zero failures. Remaining duplicates (thiserror 1.x, rand 0.8, hashbrown x3, ring/aws-lc-rs) are upstream-blocked; 

See
`docs/architecture/dependency-consolidation.md` for the full analysis, methodology, and downstream compatibility notes. Feel free to delete that doc if it seems polluting or unnecessary for long term documentation.